### PR TITLE
`offset_lms_sampling`: Provide closure for changing tangent

### DIFF
--- a/tests/bezier/offset.rs
+++ b/tests/bezier/offset.rs
@@ -219,7 +219,7 @@ fn offset_lms_sampling_arc_start_tangent() {
     let arc_curve   = arc.to_bezier_curve::<Curve<Coord2>>();
 
     // Offset by 10
-    let offset_arc  = offset_lms_sampling(&arc_curve, |_t| 10.0, 20, 0.01).expect("Offset curve");
+    let offset_arc  = offset_lms_sampling(&arc_curve, |_t| 10.0, |t| 0.0, 20, 0.01).expect("Offset curve");
 
     let start_tangent_original  = arc_curve.tangent_at_pos(0.0).to_unit_vector();
     let start_tangent_new       = offset_arc[0].tangent_at_pos(0.0).to_unit_vector();
@@ -239,7 +239,7 @@ fn offset_lms_sampling_arc_end_tangent() {
     let arc_curve   = arc.to_bezier_curve::<Curve<Coord2>>();
 
     // Offset by 10
-    let offset_arc  = offset_lms_sampling(&arc_curve, |_t| 10.0, 20, 0.01).expect("Offset curve");
+    let offset_arc  = offset_lms_sampling(&arc_curve, |_t| 10.0, |t| 0.0, 20, 0.01).expect("Offset curve");
 
     let end_tangent_original    = arc_curve.tangent_at_pos(1.0).to_unit_vector();
     let end_tangent_new         = offset_arc[offset_arc.len()-1].tangent_at_pos(1.0).to_unit_vector();
@@ -259,7 +259,7 @@ fn offset_lms_sampling_arc_end_point() {
     let arc_curve   = arc.to_bezier_curve::<Curve<Coord2>>();
 
     // Offset by 10
-    let offset_arc  = offset_lms_sampling(&arc_curve, |_t| 10.0, 20, 0.01).expect("Offset curve");
+    let offset_arc  = offset_lms_sampling(&arc_curve, |_t| 10.0, |t| 0.0, 20, 0.01).expect("Offset curve");
 
     let end_point_original      = arc_curve.point_at_pos(1.0);
     let end_point_new           = offset_arc[offset_arc.len()-1].point_at_pos(1.0);
@@ -281,7 +281,7 @@ fn offset_lms_sampling_arc_fit_single_curve() {
     let arc_curve   = arc.to_bezier_curve::<Curve<Coord2>>();
 
     // Offset by 10
-    let offset_arc  = offset_lms_sampling(&arc_curve, |_t| 10.0, 20, 1.0).expect("Offset curve");
+    let offset_arc  = offset_lms_sampling(&arc_curve, |_t| 10.0, |t| 0.0, 20, 1.0).expect("Offset curve");
 
     // We should be able to find a single bezier curve that fits these points
     assert!(offset_arc.len() == 1);


### PR DESCRIPTION
This code is adapted from changes made to [MFEK/flo_curves](https://github.com/MFEK/flo_curves/) by @MatthewBlanchard. Unlike Blanchard's code, I decided to break the backwards compatibility in a different way, instead of changing the closure type, I change the function arguments. This means users won't need to change their closures and may simply add `|t|0.` where necessary to continue on as before.