### PR TITLE
Add configurable accuracy version of `solve_curve_for_t`

### DIFF
--- a/src/bezier/solve.rs
+++ b/src/bezier/solve.rs
@@ -46,6 +46,14 @@ pub fn solve_basis_for_t(w1: f64, w2: f64, w3: f64, w4: f64, p: f64) -> SmallVec
 /// be used to retrieve it
 ///
 pub fn solve_curve_for_t<C: BezierCurve>(curve: &C, point: &C::Point) -> Option<f64> {
+    solve_curve_for_t_within(curve, point, None)
+}
+
+///
+/// Equivalent to `solve_curve_for_t`, just with a configurable `accuracy`, by default
+/// `SMALL_DISTANCE * 50.0`.
+///
+pub fn solve_curve_for_t_within<C: BezierCurve>(curve: &C, point: &C::Point, accuracy: Option<f64>) -> Option<f64> {
     let p1              = curve.start_point();
     let (p2, p3)        = curve.control_points();
     let p4              = curve.end_point();
@@ -64,7 +72,7 @@ pub fn solve_curve_for_t<C: BezierCurve>(curve: &C, point: &C::Point) -> Option<
 
             // If this is an accurate enough solution, return this as the t value
             let point_at_t  = curve.point_at_pos(possible_t);
-            if point_at_t.is_near_to(point, CLOSE_ENOUGH) {
+            if point_at_t.is_near_to(point, accuracy.unwrap_or(CLOSE_ENOUGH)) {
                 return Some(possible_t);
             }
         }


### PR DESCRIPTION
+`solve_curve_for_t_within`

This code splits the difference between @MatthewBlanchard's solution (to add `accuracy` to `solve_curve_for_t` and break user code) and upstream.