### PR TITLE
Fix panic in exterior_paths(): the point ordering isn't a total order

### DIFF
--- a/src/bezier/path/graph_path/mod.rs
+++ b/src/bezier/path/graph_path/mod.rs
@@ -1047,23 +1047,24 @@ impl<Point: Coordinate+Coordinate2D, Label: Copy> GraphPath<Point, Label> {
         // problem to show up. Ordering like this reduces the incidence of this issue by making it so we find paths by working inwards
         // instead of randomly (though a most of the time this issue does not occur, so this is wasted effort, though having outer paths
         // come before inner paths is a side-benefit)
+        // Points whose x values are close together are treated as sharing an x value and are ordered by y instead. That grouping is
+        // done by quantising x rather than by comparing pairs of x values against a tolerance: a tolerance comparison is not
+        // transitive (`a` and `b` can be within the tolerance, and `b` and `c` within it, while `a` and `c` are not), which makes
+        // this an invalid strict weak ordering, and `sort_by` is documented as being allowed to panic when it detects one
+        const SAME_X_TOLERANCE: f64 = 0.01;
+
         let mut points = (0..self.points.len()).into_iter().collect::<Vec<_>>();
         points.sort_by(|point_a, point_b| {
-            use std::cmp::{Ordering};
+            let x_a = (self.points[*point_a].position.x()/SAME_X_TOLERANCE).floor();
+            let x_b = (self.points[*point_b].position.x()/SAME_X_TOLERANCE).floor();
 
-            let x_a = self.points[*point_a].position.x();
-            let x_b = self.points[*point_b].position.x();
+            x_a.total_cmp(&x_b)
+                .then_with(|| {
+                    let y_a = self.points[*point_a].position.y();
+                    let y_b = self.points[*point_b].position.y();
 
-            if (x_a - x_b).abs() < 0.01 {
-                let y_a = self.points[*point_a].position.y();
-                let y_b = self.points[*point_b].position.y();
-
-                y_a.partial_cmp(&y_b).unwrap_or(Ordering::Equal)
-            } else if x_a < x_b {
-                Ordering::Less
-            } else {
-                Ordering::Greater
-            }
+                    y_a.total_cmp(&y_b)
+                })
         });
 
         // Store a list of edges that have been visited or are already in a path (these are flags: up to 32 edges per point are allowed by this algorithm)

--- a/tests/bezier/path/exterior_paths_ordering.rs
+++ b/tests/bezier/path/exterior_paths_ordering.rs
@@ -1,0 +1,99 @@
+use flo_curves::*;
+use flo_curves::bezier::path::*;
+
+///
+/// A deterministic stand-in for a random number generator, so this test does
+/// not need a dependency and always builds the same path.
+///
+struct Jitter(u64);
+
+impl Jitter {
+    fn next(&mut self) -> f64 {
+        // xorshift64
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+
+        ((x >> 11) as f64) / ((1u64 << 53) as f64)
+    }
+}
+
+///
+/// Builds a tall, very narrow closed path: the vertices climb in y while their
+/// x values jitter inside a band a few hundredths wide, so they arrive in no
+/// particular x order.
+///
+/// That is the shape that matters for the ordering used by `exterior_paths()`:
+/// some pairs of vertices are closer together in x than the tolerance and some
+/// are further apart, and they are not encountered in sorted order.
+///
+fn narrow_jittered_spike(num_points: usize, x_band: f64) -> SimpleBezierPath {
+    let mut jitter  = Jitter(0x2545_F491_4F6C_DD1D);
+    let mut builder = BezierPathBuilder::<SimpleBezierPath>::start(Coord2(0.0, 0.0));
+
+    for idx in 0..num_points {
+        let x = jitter.next() * x_band;
+        let y = (idx as f64) * 0.5 + 1.0;
+
+        builder = builder.line_to(Coord2(x, y));
+    }
+
+    // Close the path back around the outside
+    builder = builder.line_to(Coord2(x_band + 5.0, (num_points as f64) * 0.5 + 1.0));
+    builder = builder.line_to(Coord2(x_band + 5.0, 0.0));
+    builder = builder.line_to(Coord2(0.0, 0.0));
+
+    builder.build()
+}
+
+///
+/// `exterior_paths()` orders the points of the graph before walking them, and
+/// compares their x values with a tolerance: points within 0.01 of each other
+/// are treated as sharing an x and ordered by y instead.
+///
+/// A tolerance comparison is not transitive. `a` and `b` can be within the
+/// tolerance, and `b` and `c` within it, while `a` and `c` are not -- so the
+/// ordering can report `a < b`, `b < c` and `c < a` at the same time. That is
+/// not a valid strict weak ordering, and `sort_by` is documented as being
+/// allowed to panic when it detects one, which current Rust versions do:
+/// "user-provided comparison function does not correctly implement a total
+/// order".
+///
+/// Every path arithmetic operation ends in `exterior_paths()`, so any of them
+/// can hit this on artwork with many closely spaced points.
+///
+#[test]
+fn add_paths_with_many_near_aligned_points() {
+    let spike = narrow_jittered_spike(120, 0.05);
+    let other = BezierPathBuilder::<SimpleBezierPath>::start(Coord2(-1.0, -1.0))
+        .line_to(Coord2(2.0, -1.0))
+        .line_to(Coord2(2.0, 70.0))
+        .line_to(Coord2(-1.0, 70.0))
+        .line_to(Coord2(-1.0, -1.0))
+        .build();
+
+    let combined = path_add::<SimpleBezierPath>(&vec![spike], &vec![other], 0.01);
+
+    assert!(!combined.is_empty());
+}
+
+///
+/// The same path, subtracted rather than added: `path_sub` reaches the same
+/// ordering code.
+///
+#[test]
+fn subtract_paths_with_many_near_aligned_points() {
+    let spike = narrow_jittered_spike(120, 0.05);
+    let other = BezierPathBuilder::<SimpleBezierPath>::start(Coord2(-1.0, 10.0))
+        .line_to(Coord2(2.0, 10.0))
+        .line_to(Coord2(2.0, 40.0))
+        .line_to(Coord2(-1.0, 40.0))
+        .line_to(Coord2(-1.0, 10.0))
+        .build();
+
+    let combined = path_sub::<SimpleBezierPath>(&vec![spike], &vec![other], 0.01);
+
+    assert!(!combined.is_empty());
+}

--- a/tests/bezier/path/mod.rs
+++ b/tests/bezier/path/mod.rs
@@ -16,3 +16,4 @@ mod arithmetic_intersect;
 mod arithmetic_complicated_paths;
 mod rays;
 mod stroke_tests;
+mod exterior_paths_ordering;


### PR DESCRIPTION
### The problem

`GraphPath::exterior_paths()` orders the points of the graph before walking them, comparing x values against a tolerance:

```rust
if (x_a - x_b).abs() < 0.01 {
    y_a.partial_cmp(&y_b).unwrap_or(Ordering::Equal)
} else if x_a < x_b { Ordering::Less } else { Ordering::Greater }
```

A tolerance comparison isn't transitive. `a` and `b` can be within 0.01, and `b` and `c` within 0.01, while `a` and `c` are not — so the ordering can report `a < b`, `b < c` and `c < a` at the same time. That isn't a valid strict weak ordering, and `sort_by` is documented as being allowed to panic when it detects one. Current Rust versions do:

```
thread '...' panicked at library/core/src/slice/sort/shared/smallsort.rs:854:5:
user-provided comparison function does not correctly implement a total order
```

Every path arithmetic operation ends in `exterior_paths()`, so `path_add`, `path_sub`, `path_intersect`, `path_cut` and the rest can all reach it. It needs a path with enough closely spaced points that arrive in no particular x order — a monotonic sweep doesn't trigger it, which is probably why it has gone unnoticed, but jittered or generated artwork does. Measuring the comparator in isolation over random points clustered in a narrow x band: at 24 points ~70% of sets panic, and by 128 points it's ~98%.

### The change

Quantise x into tolerance-wide buckets instead of comparing pairs against a tolerance. Points that are close together still sort together and are still ordered by y — the intent of the original comment is preserved — but the grouping becomes an equivalence relation, so the ordering is well defined. `total_cmp` is used so the result stays a total order even if a coordinate is NaN.

The two tests added with this build a tall, narrow path whose vertices jitter within a 0.05-wide band; both panic without the change and pass with it. The rest of the suite is unaffected: 791 tests pass, 0 failures.

### Unrelated finding, happy to file separately

While tracing this I noticed `GraphPath::round()` is a no-op:

```rust
// src/bezier/path/graph_path/mod.rs:583
self.points[point_idx].position.round(accuracy);
```

`Coordinate::round` is `fn round(self, f64) -> Self`, so this computes the rounded coordinate and discards it — the same on the two `cp1`/`cp2` lines below it. Nothing catches it because `Coordinate: Copy` makes discarding the result legal rather than a move error, and the method isn't `#[must_use]`. The nine callers in the arithmetic modules are all correct; only the body is affected. The fix would be `self.points[point_idx].position = self.points[point_idx].position.round(accuracy);`.

I left it out of this PR because making it actually round would change output for existing users, which felt like your call rather than something to fold into a crash fix. Glad to open an issue or a separate PR, whichever you prefer.